### PR TITLE
Add Pulumi infrastructure and deployment workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,29 @@
+name: Deploy Infrastructure
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '16'
+      - name: Install dependencies
+        run: npm install
+        working-directory: infra
+      - uses: pulumi/actions@v3
+        with:
+          command: up
+          stack-name: dev
+          work-dir: infra
+        env:
+          PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
+          ARM_CLIENT_ID: ${{ secrets.ARM_CLIENT_ID }}
+          ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET }}
+          ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
+          ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID }}

--- a/infra/Pulumi.dev.yaml
+++ b/infra/Pulumi.dev.yaml
@@ -1,0 +1,2 @@
+config:
+  azure-native:location: centralindia

--- a/infra/Pulumi.yaml
+++ b/infra/Pulumi.yaml
@@ -1,0 +1,3 @@
+name: lightning
+runtime: nodejs
+description: Azure resources for lightning

--- a/infra/index.ts
+++ b/infra/index.ts
@@ -1,0 +1,33 @@
+import * as pulumi from "@pulumi/pulumi";
+import * as azure from "@pulumi/azure-native";
+
+const config = new pulumi.Config();
+const location = config.get("location") || "centralindia";
+
+const resourceGroup = new azure.resources.ResourceGroup("lightning", {
+    resourceGroupName: "lightning",
+    location,
+});
+
+const namespace = new azure.eventhub.Namespace("lightning-namespace", {
+    resourceGroupName: resourceGroup.name,
+    namespaceName: "lightning-namespace",
+    location: resourceGroup.location,
+    sku: {
+        name: "Standard",
+        tier: "Standard",
+    },
+    kafkaEnabled: true,
+});
+
+const eventHub = new azure.eventhub.EventHub("lightning-hub", {
+    resourceGroupName: resourceGroup.name,
+    namespaceName: namespace.name,
+    eventHubName: "lightning-hub",
+    partitionCount: 2,
+    messageRetentionInDays: 1,
+});
+
+export const resourceGroupName = resourceGroup.name;
+export const eventHubNamespaceName = namespace.name;
+export const eventHubName = eventHub.name;

--- a/infra/package.json
+++ b/infra/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "lightning-infra",
+  "version": "1.0.0",
+  "main": "index.js",
+  "license": "MIT",
+  "dependencies": {
+    "@pulumi/pulumi": "^3.0.0",
+    "@pulumi/azure-native": "^2.0.0"
+  }
+}


### PR DESCRIPTION
## Summary
- add Pulumi program to create a resource group and EventHub (Kafka-compatible)
- add stack configuration and package.json
- add GitHub Actions workflow to deploy on push to `main`
- use central India region for the stack

## Testing
- `npm install` *(fails: EHOSTUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_6839e390a008832eb57176ac50fa5aea