### PR TITLE
Add mandatory user ID for events

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,13 +8,15 @@ Deploying the infrastructure will create an Azure Function that exposes an HTTP 
 
 ### PUT /api/events
 
-Send a JSON body describing the event:
+Include a header `X-User-ID` identifying the user on whose behalf the event was
+generated. Send a JSON body describing the event:
 
 ```json
 {
   "timestamp": "2023-01-01T00:00:00Z",
   "source": "sensor-1",
   "type": "movement",
+  "userID": "abc123",
   "metadata": {"x": 1, "y": 2}
 }
 ```

--- a/azure-function/PutEvent/__init__.py
+++ b/azure-function/PutEvent/__init__.py
@@ -19,6 +19,11 @@ def main(req: func.HttpRequest) -> func.HttpResponse:
     except ValueError:
         return func.HttpResponse("Invalid JSON", status_code=400)
 
+    user_id = req.headers.get("x-user-id")
+    if not user_id:
+        return func.HttpResponse("Missing user ID", status_code=400)
+    data["userID"] = user_id
+
     try:
         event = Event.from_dict(data)
     except ValueError as e:

--- a/events/__init__.py
+++ b/events/__init__.py
@@ -8,6 +8,7 @@ class Event:
     timestamp: datetime
     source: str
     type: str
+    user_id: str
     metadata: Dict[str, Any] = field(default_factory=dict)
     id: Optional[str] = None
 
@@ -19,6 +20,8 @@ class Event:
             raise ValueError("source required")
         if "type" not in data:
             raise ValueError("type required")
+        if "userID" not in data:
+            raise ValueError("userID required")
         ts = data["timestamp"]
         if isinstance(ts, str):
             timestamp = datetime.fromisoformat(ts)
@@ -30,6 +33,7 @@ class Event:
             timestamp=timestamp,
             source=data["source"],
             type=data["type"],
+            user_id=data["userID"],
             metadata=data.get("metadata", {}),
             id=data.get("id"),
         )
@@ -39,6 +43,7 @@ class Event:
             "timestamp": self.timestamp.isoformat(),
             "source": self.source,
             "type": self.type,
+            "userID": self.user_id,
             "metadata": self.metadata,
             "id": self.id,
         }

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -1,0 +1,32 @@
+import os
+import sys
+from datetime import datetime
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from events import Event
+
+
+def test_event_requires_userid():
+    data = {
+        "timestamp": datetime.now().isoformat(),
+        "source": "s",
+        "type": "t",
+    }
+    with pytest.raises(ValueError):
+        Event.from_dict(data)
+
+
+def test_event_round_trip():
+    now = datetime.now()
+    data = {
+        "timestamp": now.isoformat(),
+        "source": "s",
+        "type": "t",
+        "userID": "u1",
+        "metadata": {"a": 1},
+    }
+    event = Event.from_dict(data)
+    assert event.user_id == "u1"
+    out = event.to_dict()
+    assert out["userID"] == "u1"


### PR DESCRIPTION
## Summary
- require `userID` when constructing events
- populate `userID` in the `PutEvent` function using the `X-User-ID` header
- document the new requirement in the README
- add tests for `Event` handling

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683b21936370832e816bb612ade86ee1