### PR TITLE
Add event matching utility

### DIFF
--- a/events/utils.py
+++ b/events/utils.py
@@ -1,0 +1,6 @@
+from fnmatch import fnmatchcase
+
+
+def event_matches(event_type: str, pattern: str) -> bool:
+    """Return True if the event_type matches the glob-style pattern."""
+    return fnmatchcase(event_type, pattern)

--- a/tests/test_event_utils.py
+++ b/tests/test_event_utils.py
@@ -1,0 +1,25 @@
+import os, sys
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+import pytest
+
+from events.utils import event_matches
+
+
+def test_simple_match():
+    assert event_matches('llm.chat.request', 'llm.chat.*')
+
+
+def test_middle_wildcard():
+    assert event_matches('llm.chat.request', 'llm.*.request')
+
+
+def test_no_match():
+    assert not event_matches('llm.chat.request', 'llm.chat.response')
+
+
+def test_exact_match():
+    assert event_matches('llm.chat', 'llm.chat')
+
+
+def test_prefix_wildcard():
+    assert event_matches('llm.chat', 'llm.*')


### PR DESCRIPTION
## Summary
- add `event_matches` using `fnmatch.fnmatchcase`
- test matching behaviour for different patterns

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683b21dd688c832e81e67dcfc9c6daca