### PR TITLE
Add LLMChatEvent event type

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,3 +26,10 @@ The function validates the data and publishes it to the Service Bus queue. The `
 ## Python library
 
 The `events` package provides a dataclass `Event` that can be used to structure events before they are sent to the API or processed downstream.
+
+### LLMChatEvent
+
+`LLMChatEvent` extends `Event` and expects a list of chat messages stored under
+`metadata.messages`. Each message should be a mapping with at least `role` and
+`content` keys. When `LLMChatEvent.to_dict()` is called, the messages are
+ensured to appear under the `metadata` key.

--- a/events/__init__.py
+++ b/events/__init__.py
@@ -1,6 +1,6 @@
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, asdict
 from datetime import datetime
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, List
 
 
 @dataclass
@@ -47,3 +47,25 @@ class Event:
             "metadata": self.metadata,
             "id": self.id,
         }
+
+
+@dataclass
+class LLMChatEvent(Event):
+    """Event representing an LLM chat interaction."""
+
+    messages: List[Any] = field(default_factory=list)
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "LLMChatEvent":
+        base = Event.from_dict(data)
+        msgs = base.metadata.get("messages")
+        if not msgs:
+            raise ValueError("metadata.messages required")
+        return cls(**asdict(base), messages=msgs)
+
+    def to_dict(self) -> Dict[str, Any]:
+        d = super().to_dict()
+        meta = dict(d.get("metadata", {}))
+        meta["messages"] = self.messages
+        d["metadata"] = meta
+        return d

--- a/tests/test_llm_chat_event.py
+++ b/tests/test_llm_chat_event.py
@@ -1,0 +1,35 @@
+import os
+import sys
+from datetime import datetime
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+from events import LLMChatEvent
+
+
+def test_llmchat_missing_messages():
+    data = {
+        "timestamp": datetime.now().isoformat(),
+        "source": "s",
+        "type": "llm.chat",
+        "userID": "u1",
+        "metadata": {},
+    }
+    with pytest.raises(ValueError):
+        LLMChatEvent.from_dict(data)
+
+
+def test_llmchat_round_trip():
+    now = datetime.now()
+    msgs = [{"role": "user", "content": "hi"}]
+    data = {
+        "timestamp": now.isoformat(),
+        "source": "s",
+        "type": "llm.chat",
+        "userID": "u1",
+        "metadata": {"messages": msgs},
+    }
+    event = LLMChatEvent.from_dict(data)
+    assert event.messages == msgs
+    out = event.to_dict()
+    assert out["metadata"]["messages"] == msgs


### PR DESCRIPTION
## Summary
- add `LLMChatEvent` dataclass that extends `Event`
- ensure metadata carries messages when serializing
- describe `LLMChatEvent` usage in README
- test parsing and serialization of `LLMChatEvent`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683b2836eb74832ea63ed55c3e075d11