### PR TITLE
Add ChatResponder function

### DIFF
--- a/azure-function/ChatResponder/__init__.py
+++ b/azure-function/ChatResponder/__init__.py
@@ -1,0 +1,53 @@
+import json
+import logging
+import os
+from datetime import datetime
+
+import azure.functions as func
+from azure.servicebus import ServiceBusClient, ServiceBusMessage
+import openai
+
+from events import Event, LLMChatEvent
+
+SERVICEBUS_CONN = os.environ.get("SERVICEBUS_CONNECTION")
+SERVICEBUS_QUEUE = os.environ.get("SERVICEBUS_QUEUE")
+
+client = ServiceBusClient.from_connection_string(SERVICEBUS_CONN)
+
+
+def main(msg: func.ServiceBusMessage) -> None:
+    body = msg.get_body().decode("utf-8")
+    try:
+        data = json.loads(body)
+        event = LLMChatEvent.from_dict(data)
+    except Exception as e:
+        logging.error("Invalid event: %s", e)
+        return
+
+    try:
+        response = openai.ChatCompletion.create(messages=event.messages)
+        reply = response["choices"][0]["message"]["content"]
+        logging.info("Assistant reply: %s", reply)
+    except Exception as e:
+        logging.error("ChatCompletion failed: %s", e)
+        return
+
+    out_event = Event(
+        timestamp=datetime.utcnow(),
+        source="ChatResponder",
+        type="llm.chat.response",
+        user_id=event.user_id,
+        metadata={"reply": reply},
+    )
+
+    message = ServiceBusMessage(json.dumps(out_event.to_dict()))
+    message.application_properties = {"topic": out_event.type}
+
+    try:
+        with client:
+            sender = client.get_queue_sender(queue_name=SERVICEBUS_QUEUE)
+            with sender:
+                sender.send_messages(message)
+    except Exception as e:
+        logging.error("Failed to publish response: %s", e)
+

--- a/azure-function/ChatResponder/function.json
+++ b/azure-function/ChatResponder/function.json
@@ -1,0 +1,11 @@
+{
+  "bindings": [
+    {
+      "type": "serviceBusTrigger",
+      "direction": "in",
+      "name": "msg",
+      "queueName": "%SERVICEBUS_QUEUE%",
+      "connection": "SERVICEBUS_CONNECTION"
+    }
+  ]
+}

--- a/azure-function/requirements.txt
+++ b/azure-function/requirements.txt
@@ -1,2 +1,3 @@
 azure-functions
 azure-servicebus
+openai


### PR DESCRIPTION
## Summary
- create new ChatResponder Azure Function triggered by ServiceBus
- respond to chat events using OpenAI
- publish response events back to ServiceBus
- add openai dependency

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683b292b8d88832e88fbc3eba6bc686b