### PR TITLE
Implement automatic event ID generation

### DIFF
--- a/events/__init__.py
+++ b/events/__init__.py
@@ -1,6 +1,7 @@
 from dataclasses import dataclass, field, asdict
 from datetime import datetime
 from typing import Any, Dict, Optional, List
+import uuid
 
 
 @dataclass
@@ -35,7 +36,7 @@ class Event:
             type=data["type"],
             user_id=data["userID"],
             metadata=data.get("metadata", {}),
-            id=data.get("id"),
+            id=data.get("id") or uuid.uuid4().hex,
         )
 
     def to_dict(self) -> Dict[str, Any]:

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -30,3 +30,18 @@ def test_event_round_trip():
     assert event.user_id == "u1"
     out = event.to_dict()
     assert out["userID"] == "u1"
+
+
+def test_event_auto_generates_id():
+    data = {
+        "timestamp": datetime.now().isoformat(),
+        "source": "s",
+        "type": "t",
+        "userID": "u2",
+    }
+    event = Event.from_dict(data)
+    assert event.id is not None
+    # id should be a 32 character hex string
+    assert isinstance(event.id, str) and len(event.id) == 32
+    out = event.to_dict()
+    assert out["id"] == event.id


### PR DESCRIPTION
## Summary
- generate a new UUID for `Event` objects when no ID is supplied
- test that IDs are created automatically

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683b58137790832e9516267a14a3ac9a