### PR TITLE
Add OPENAI_MODEL setting to ChatResponder

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ The function requires the following application settings:
 - `SERVICEBUS_CONNECTION` – connection string for the queue.
 - `SERVICEBUS_QUEUE` – name of the queue containing chat events.
 - `OPENAI_API_KEY` – API key used by the `openai` library.
+- `OPENAI_MODEL` – model name passed to OpenAI. Defaults to `gpt-3.5-turbo`.
 
 ### Expected event
 
@@ -122,6 +123,8 @@ messaging:
 
 - `OPENAI_API_KEY` &mdash; API key used by the `ChatResponder` function when
   calling OpenAI.
+- `OPENAI_MODEL` &mdash; model name for ChatResponder when calling OpenAI 
+  (defaults to `gpt-3.5-turbo`).
 - `SERVICEBUS_CONNECTION` &mdash; connection string for the Service Bus
   namespace.
 - `SERVICEBUS_QUEUE` &mdash; queue name for publishing and receiving events.

--- a/azure-function/ChatResponder/__init__.py
+++ b/azure-function/ChatResponder/__init__.py
@@ -11,6 +11,7 @@ from events import Event, LLMChatEvent
 
 SERVICEBUS_CONN = os.environ.get("SERVICEBUS_CONNECTION")
 SERVICEBUS_QUEUE = os.environ.get("SERVICEBUS_QUEUE")
+OPENAI_MODEL = os.environ.get("OPENAI_MODEL", "gpt-3.5-turbo")
 
 client = ServiceBusClient.from_connection_string(SERVICEBUS_CONN)
 
@@ -25,7 +26,10 @@ def main(msg: func.ServiceBusMessage) -> None:
         return
 
     try:
-        response = openai.ChatCompletion.create(messages=event.messages)
+        response = openai.ChatCompletion.create(
+            messages=event.messages,
+            model=OPENAI_MODEL,
+        )
         reply = response["choices"][0]["message"]["content"]
         logging.info("Assistant reply: %s", reply)
     except Exception as e:

--- a/tests/test_chat_responder.py
+++ b/tests/test_chat_responder.py
@@ -1,0 +1,89 @@
+import os
+import sys
+import json
+import types
+import importlib.util
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+
+def load_chat_responder(monkeypatch, capture):
+    # stub openai module
+    openai_stub = types.ModuleType('openai')
+    class ChatStub:
+        @staticmethod
+        def create(messages=None, model=None):
+            capture['model'] = model
+            return {"choices": [{"message": {"content": "ok"}}]}
+    openai_stub.ChatCompletion = ChatStub
+    monkeypatch.setitem(sys.modules, 'openai', openai_stub)
+
+    # stub azure functions
+    azure_mod = types.ModuleType('azure')
+    func_mod = types.ModuleType('functions')
+    class DummySBMessage:
+        def __init__(self, body):
+            self._body = body.encode('utf-8')
+        def get_body(self):
+            return self._body
+    func_mod.ServiceBusMessage = DummySBMessage
+    azure_mod.functions = func_mod
+
+    sb_mod = types.ModuleType('servicebus')
+    class DummySender:
+        def __enter__(self):
+            return self
+        def __exit__(self, exc_type, exc, tb):
+            pass
+        def send_messages(self, msg):
+            pass
+    class DummyClient:
+        def __enter__(self):
+            return self
+        def __exit__(self, exc_type, exc, tb):
+            pass
+        def get_queue_sender(self, queue_name=None):
+            return DummySender()
+    sb_mod.ServiceBusClient = types.SimpleNamespace(
+        from_connection_string=lambda *a, **k: DummyClient()
+    )
+    class DummyOutMessage:
+        def __init__(self, body):
+            self.body = body
+            self.application_properties = {}
+    sb_mod.ServiceBusMessage = DummyOutMessage
+    azure_mod.servicebus = sb_mod
+
+    monkeypatch.setitem(sys.modules, 'azure', azure_mod)
+    monkeypatch.setitem(sys.modules, 'azure.functions', func_mod)
+    monkeypatch.setitem(sys.modules, 'azure.servicebus', sb_mod)
+
+    spec = importlib.util.spec_from_file_location(
+        'ChatResponder',
+        os.path.join(os.path.dirname(__file__), '..', 'azure-function', 'ChatResponder', '__init__.py')
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules['ChatResponder'] = module
+    spec.loader.exec_module(module)
+    return module, func_mod.ServiceBusMessage
+
+
+def test_openai_model_env(monkeypatch):
+    os.environ['SERVICEBUS_CONNECTION'] = 'endpoint'
+    os.environ['SERVICEBUS_QUEUE'] = 'queue'
+    os.environ['OPENAI_MODEL'] = 'test-model'
+
+    captured = {}
+    module, SBMessage = load_chat_responder(monkeypatch, captured)
+
+    event = {
+        "timestamp": "2023-01-01T00:00:00Z",
+        "source": "test",
+        "type": "llm.chat",
+        "userID": "u",
+        "metadata": {"messages": [{"role": "user", "content": "hi"}]},
+    }
+    msg = SBMessage(json.dumps(event))
+    module.main(msg)
+
+    assert captured['model'] == 'test-model'


### PR DESCRIPTION
## Summary
- make ChatResponder read `OPENAI_MODEL` environment variable
- pass model name when calling OpenAI
- document `OPENAI_MODEL` in the README
- test that ChatResponder uses the configured model

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683b57f77128832eb9480dd1a61003b4