### PR TITLE
Add env var checks to Azure Functions

### DIFF
--- a/azure-function/ChatResponder/__init__.py
+++ b/azure-function/ChatResponder/__init__.py
@@ -13,6 +13,15 @@ SERVICEBUS_CONN = os.environ.get("SERVICEBUS_CONNECTION")
 SERVICEBUS_QUEUE = os.environ.get("SERVICEBUS_QUEUE")
 OPENAI_MODEL = os.environ.get("OPENAI_MODEL", "gpt-3.5-turbo")
 
+missing = []
+if not SERVICEBUS_CONN:
+    missing.append("SERVICEBUS_CONNECTION")
+if not SERVICEBUS_QUEUE:
+    missing.append("SERVICEBUS_QUEUE")
+if missing:
+    logging.error("Missing required environment variable(s): %s", ", ".join(missing))
+    raise RuntimeError("Azure Function misconfigured")
+
 client = ServiceBusClient.from_connection_string(SERVICEBUS_CONN)
 
 

--- a/azure-function/PutEvent/__init__.py
+++ b/azure-function/PutEvent/__init__.py
@@ -11,10 +11,21 @@ from events import Event
 SERVICEBUS_CONN = os.environ.get("SERVICEBUS_CONNECTION")
 SERVICEBUS_QUEUE = os.environ.get("SERVICEBUS_QUEUE")
 
-client = ServiceBusClient.from_connection_string(SERVICEBUS_CONN)
+client = None
+if SERVICEBUS_CONN:
+    client = ServiceBusClient.from_connection_string(SERVICEBUS_CONN)
 
 
 def main(req: func.HttpRequest) -> func.HttpResponse:
+    missing = []
+    if not SERVICEBUS_CONN:
+        missing.append("SERVICEBUS_CONNECTION")
+    if not SERVICEBUS_QUEUE:
+        missing.append("SERVICEBUS_QUEUE")
+    if missing:
+        logging.error("Missing required environment variable(s): %s", ", ".join(missing))
+        return func.HttpResponse("Service not configured", status_code=500)
+
     try:
         data = req.get_json()
     except ValueError:

--- a/azure-function/UserMessenger/__init__.py
+++ b/azure-function/UserMessenger/__init__.py
@@ -10,6 +10,10 @@ from events.utils import event_matches
 
 NOTIFY_URL = os.environ.get("NOTIFY_URL")
 
+if not NOTIFY_URL:
+    logging.error("Missing required environment variable: NOTIFY_URL")
+    raise RuntimeError("Azure Function misconfigured")
+
 
 def main(msg: func.ServiceBusMessage) -> None:
     body = msg.get_body().decode("utf-8")


### PR DESCRIPTION
## Summary
- fail fast in each function when mandatory environment variables are missing
- return HTTP 500 for missing configuration in `PutEvent`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683b5e104630832e8a45a6006ca36ba4