### PR TITLE
Handle failure responses from HTTP requests

### DIFF
--- a/azure-function/UserMessenger/__init__.py
+++ b/azure-function/UserMessenger/__init__.py
@@ -33,7 +33,9 @@ def main(msg: func.ServiceBusMessage) -> None:
         return
 
     try:
-        requests.post(NOTIFY_URL, json={"user_id": event.user_id, "message": user_text})
+        resp = requests.post(NOTIFY_URL, json={"user_id": event.user_id, "message": user_text})
+        if not 200 <= resp.status_code < 300:
+            logging.warning("Notify endpoint returned status %s: %s", resp.status_code, resp.text)
     except Exception as e:
         logging.error("Failed to notify user: %s", e)
 

--- a/chat_client/chainlit_app.py
+++ b/chat_client/chainlit_app.py
@@ -1,6 +1,7 @@
 import os
 from datetime import datetime
 
+import logging
 import requests
 import chainlit as cl
 from fastapi import HTTPException
@@ -27,7 +28,9 @@ async def on_message(message: cl.Message):
 
     headers = {"X-User-ID": message.author}
     try:
-        requests.post(EVENT_API_URL, json=event, headers=headers)
+        resp = requests.post(EVENT_API_URL, json=event, headers=headers)
+        if not 200 <= resp.status_code < 300:
+            logging.warning("Event API returned status %s: %s", resp.status_code, resp.text)
     except Exception as e:
         await cl.Message(content=f"Failed to send event: {e}", author="system").send()
         return


### PR DESCRIPTION
## Summary
- add logging of non-successful HTTP responses
- surface error when event or notify endpoints return non-2xx

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683b5e1bb9ac832e9dfe8be1fb2d03e7