### PR TITLE
Support Z timestamps for Event

### DIFF
--- a/events/__init__.py
+++ b/events/__init__.py
@@ -25,7 +25,12 @@ class Event:
             raise ValueError("userID required")
         ts = data["timestamp"]
         if isinstance(ts, str):
-            timestamp = datetime.fromisoformat(ts)
+            if ts.endswith("Z"):
+                ts = ts[:-1] + "+00:00"
+            try:
+                timestamp = datetime.fromisoformat(ts)
+            except ValueError:
+                raise ValueError("invalid timestamp")
         elif isinstance(ts, (int, float)):
             timestamp = datetime.fromtimestamp(ts)
         else:

--- a/tests/test_event.py
+++ b/tests/test_event.py
@@ -45,3 +45,14 @@ def test_event_auto_generates_id():
     assert isinstance(event.id, str) and len(event.id) == 32
     out = event.to_dict()
     assert out["id"] == event.id
+
+
+def test_event_parses_z_timezone():
+    data = {
+        "timestamp": "2023-01-01T00:00:00Z",
+        "source": "s",
+        "type": "t",
+        "userID": "u3",
+    }
+    event = Event.from_dict(data)
+    assert event.timestamp.isoformat() == "2023-01-01T00:00:00+00:00"


### PR DESCRIPTION
## Summary
- handle ISO timestamps ending in `Z` for `Event.from_dict`
- test parsing of `Z` timezone strings

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683b5e3df0b4832e9494c50c08d4da6f