### PR TITLE
Add scheduler functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,30 @@ generated. Send a JSON body describing the event:
 
 The function validates the data and publishes it to the Service Bus queue. The `type` field is used as the topic of the message.
 
+### POST /api/schedule
+
+Schedule an event for future delivery. Provide the `X-User-ID` header and a JSON
+body containing the event payload and either a one-time `timestamp` or a `cron`
+expression:
+
+```json
+{
+  "event": { "type": "user.message", "source": "client", "metadata": {"message": "hi"} },
+  "timestamp": "2023-01-01T01:00:00Z"
+}
+```
+
+or
+
+```json
+{
+  "event": { "type": "user.message", "source": "client", "metadata": {"message": "hi"} },
+  "cron": "0 * * * *"
+}
+```
+
+The function stores the schedule in durable storage and returns a schedule ID.
+
 ## Python library
 
 The `events` package provides a dataclass `Event` that can be used to structure events before they are sent to the API or processed downstream.

--- a/azure-function/ScheduleWorker/__init__.py
+++ b/azure-function/ScheduleWorker/__init__.py
@@ -1,0 +1,37 @@
+import json
+import os
+from datetime import datetime
+
+import azure.functions as func
+from azure.data.tables import TableServiceClient
+from azure.servicebus import ServiceBusClient, ServiceBusMessage
+from croniter import croniter
+
+STORAGE_CONN = os.environ.get("STORAGE_CONNECTION")
+SCHEDULE_TABLE = os.environ.get("SCHEDULE_TABLE", "schedules")
+SERVICEBUS_CONN = os.environ.get("SERVICEBUS_CONNECTION")
+SERVICEBUS_QUEUE = os.environ.get("SERVICEBUS_QUEUE")
+
+service = TableServiceClient.from_connection_string(STORAGE_CONN)
+_table = service.get_table_client(SCHEDULE_TABLE)
+_servicebus = ServiceBusClient.from_connection_string(SERVICEBUS_CONN)
+
+
+def main(mytimer: func.TimerRequest) -> None:
+    now = datetime.utcnow()
+    due_filter = f"runAt le '{now.isoformat()}'"
+    entities = list(_table.query_entities(due_filter))
+    for ent in entities:
+        event = json.loads(ent["event"])
+        msg = ServiceBusMessage(json.dumps(event))
+        msg.application_properties = {"topic": event["type"]}
+        with _servicebus:
+            sender = _servicebus.get_queue_sender(queue_name=SERVICEBUS_QUEUE)
+            with sender:
+                sender.send_messages(msg)
+        if ent.get("cron"):
+            next_time = croniter(ent["cron"], now).get_next(datetime)
+            ent["runAt"] = next_time.isoformat()
+            _table.update_entity(ent)
+        else:
+            _table.delete_entity(ent["PartitionKey"], ent["RowKey"])

--- a/azure-function/ScheduleWorker/function.json
+++ b/azure-function/ScheduleWorker/function.json
@@ -1,0 +1,10 @@
+{
+  "bindings": [
+    {
+      "name": "mytimer",
+      "type": "timerTrigger",
+      "direction": "in",
+      "schedule": "* * * * *"
+    }
+  ]
+}

--- a/azure-function/Scheduler/__init__.py
+++ b/azure-function/Scheduler/__init__.py
@@ -1,0 +1,70 @@
+import json
+import os
+import uuid
+from datetime import datetime
+
+import azure.functions as func
+from azure.data.tables import TableServiceClient
+from croniter import croniter
+
+from events import Event
+
+STORAGE_CONN = os.environ.get("STORAGE_CONNECTION")
+SCHEDULE_TABLE = os.environ.get("SCHEDULE_TABLE", "schedules")
+
+service = TableServiceClient.from_connection_string(STORAGE_CONN)
+_table = service.get_table_client(SCHEDULE_TABLE)
+_table.create_table_if_not_exists()
+
+
+def main(req: func.HttpRequest) -> func.HttpResponse:
+    try:
+        data = req.get_json()
+    except ValueError:
+        return func.HttpResponse("Invalid JSON", status_code=400)
+
+    user_id = req.headers.get("x-user-id")
+    if not user_id:
+        return func.HttpResponse("Missing user ID", status_code=400)
+
+    event_payload = data.get("event")
+    cron_expr = data.get("cron")
+    run_at = data.get("timestamp")
+
+    if not event_payload:
+        return func.HttpResponse("Missing event payload", status_code=400)
+    if not cron_expr and not run_at:
+        return func.HttpResponse("Missing schedule", status_code=400)
+
+    event_payload["userID"] = user_id
+    try:
+        Event.from_dict(event_payload)
+    except ValueError as e:
+        return func.HttpResponse(str(e), status_code=400)
+
+    if run_at:
+        try:
+            next_time = datetime.fromisoformat(run_at)
+        except Exception:
+            return func.HttpResponse("Invalid timestamp", status_code=400)
+    else:
+        try:
+            next_time = croniter(cron_expr, datetime.utcnow()).get_next(datetime)
+        except Exception:
+            return func.HttpResponse("Invalid cron expression", status_code=400)
+
+    sched_id = uuid.uuid4().hex
+    entity = {
+        "PartitionKey": user_id,
+        "RowKey": sched_id,
+        "event": json.dumps(event_payload),
+        "cron": cron_expr or "",
+        "runAt": next_time.isoformat(),
+    }
+    _table.upsert_entity(entity)
+
+    return func.HttpResponse(
+        json.dumps({"id": sched_id}),
+        status_code=201,
+        mimetype="application/json",
+    )

--- a/azure-function/Scheduler/function.json
+++ b/azure-function/Scheduler/function.json
@@ -1,0 +1,17 @@
+{
+  "bindings": [
+    {
+      "authLevel": "function",
+      "type": "httpTrigger",
+      "direction": "in",
+      "name": "req",
+      "methods": ["post"],
+      "route": "schedule"
+    },
+    {
+      "type": "http",
+      "direction": "out",
+      "name": "$return"
+    }
+  ]
+}

--- a/azure-function/requirements.txt
+++ b/azure-function/requirements.txt
@@ -2,3 +2,5 @@ azure-functions
 azure-servicebus  # or azure-eventhub if using Event Hub trigger
 openai
 requests
+azure-data-tables
+croniter

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -1,0 +1,160 @@
+import os
+import sys
+import json
+import types
+import importlib.util
+from datetime import datetime, timedelta
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+
+def load_scheduler(monkeypatch, capture):
+    azure_mod = types.ModuleType('azure')
+    tables_mod = types.ModuleType('tables')
+    class DummyTable:
+        def create_table_if_not_exists(self):
+            pass
+        def upsert_entity(self, entity):
+            capture['entity'] = entity
+    class DummyService:
+        def get_table_client(self, table):
+            return DummyTable()
+    tables_mod.TableServiceClient = types.SimpleNamespace(
+        from_connection_string=lambda *a, **k: DummyService()
+    )
+    azure_mod.data = types.SimpleNamespace(tables=tables_mod)
+    monkeypatch.setitem(sys.modules, 'azure', azure_mod)
+    monkeypatch.setitem(sys.modules, 'azure.data.tables', tables_mod)
+
+    func_mod = types.ModuleType('functions')
+    class DummyResponse:
+        def __init__(self, body='', status_code=200, mimetype=None):
+            self.body = body
+            self.status_code = status_code
+            self.mimetype = mimetype
+    class DummyRequest:
+        pass
+    func_mod.HttpResponse = DummyResponse
+    func_mod.HttpRequest = DummyRequest
+    azure_mod.functions = func_mod
+    monkeypatch.setitem(sys.modules, 'azure.functions', func_mod)
+
+    cron_mod = types.ModuleType('croniter')
+    cron_mod.croniter = lambda expr, start: types.SimpleNamespace(get_next=lambda typ: start + timedelta(minutes=5))
+    monkeypatch.setitem(sys.modules, 'croniter', cron_mod)
+
+    spec = importlib.util.spec_from_file_location(
+        'Scheduler', os.path.join(os.path.dirname(__file__), '..', 'azure-function', 'Scheduler', '__init__.py')
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules['Scheduler'] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_schedule_creation(monkeypatch):
+    os.environ['STORAGE_CONNECTION'] = 'c'
+    os.environ['SCHEDULE_TABLE'] = 't'
+    capture = {}
+    mod = load_scheduler(monkeypatch, capture)
+
+    event = {
+        'timestamp': datetime.utcnow().isoformat(),
+        'source': 's',
+        'type': 't',
+        'metadata': {}
+    }
+    req = types.SimpleNamespace(
+        get_json=lambda: {'event': event, 'timestamp': (datetime.utcnow() + timedelta(hours=1)).isoformat()},
+        headers={'x-user-id': 'u1'}
+    )
+    resp = mod.main(req)
+    assert resp.status_code == 201
+    assert capture['entity']['PartitionKey'] == 'u1'
+
+
+def load_worker(monkeypatch, schedules, sent):
+    azure_mod = types.ModuleType('azure')
+    tables_mod = types.ModuleType('tables')
+    class DummyTable:
+        def query_entities(self, *a, **k):
+            return schedules
+        def update_entity(self, e):
+            sent['updated'] = e
+        def delete_entity(self, pk, rk):
+            sent.setdefault('deleted', []).append((pk, rk))
+    class DummyService:
+        def get_table_client(self, table):
+            return DummyTable()
+    tables_mod.TableServiceClient = types.SimpleNamespace(
+        from_connection_string=lambda *a, **k: DummyService()
+    )
+    azure_mod.data = types.SimpleNamespace(tables=tables_mod)
+    monkeypatch.setitem(sys.modules, 'azure', azure_mod)
+    monkeypatch.setitem(sys.modules, 'azure.data.tables', tables_mod)
+
+    sb_mod = types.ModuleType('servicebus')
+    class DummySender:
+        def __enter__(self):
+            return self
+        def __exit__(self, exc_type, exc, tb):
+            pass
+        def send_messages(self, msg):
+            sent.setdefault('messages', []).append(json.loads(msg.body))
+    class DummyClient:
+        def __enter__(self):
+            return self
+        def __exit__(self, exc_type, exc, tb):
+            pass
+        def get_queue_sender(self, queue_name=None):
+            return DummySender()
+    sb_mod.ServiceBusClient = types.SimpleNamespace(
+        from_connection_string=lambda *a, **k: DummyClient()
+    )
+    class DummyMessage:
+        def __init__(self, body):
+            self.body = body
+            self.application_properties = {}
+    sb_mod.ServiceBusMessage = DummyMessage
+    azure_mod.servicebus = sb_mod
+    monkeypatch.setitem(sys.modules, 'azure.servicebus', sb_mod)
+
+    func_mod = types.ModuleType('functions')
+    azure_mod.functions = func_mod
+    class DummyTimer:
+        pass
+    func_mod.TimerRequest = DummyTimer
+    monkeypatch.setitem(sys.modules, 'azure.functions', func_mod)
+
+    cron_mod = types.ModuleType('croniter')
+    cron_mod.croniter = lambda expr, start: types.SimpleNamespace(get_next=lambda typ: start + timedelta(minutes=5))
+    monkeypatch.setitem(sys.modules, 'croniter', cron_mod)
+
+    spec = importlib.util.spec_from_file_location(
+        'ScheduleWorker', os.path.join(os.path.dirname(__file__), '..', 'azure-function', 'ScheduleWorker', '__init__.py')
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules['ScheduleWorker'] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_worker_publishes_event(monkeypatch):
+    os.environ['STORAGE_CONNECTION'] = 'c'
+    os.environ['SCHEDULE_TABLE'] = 't'
+    os.environ['SERVICEBUS_CONNECTION'] = 'sb'
+    os.environ['SERVICEBUS_QUEUE'] = 'q'
+
+    event = {'timestamp': datetime.utcnow().isoformat(), 'source': 's', 'type': 't', 'userID': 'u1', 'metadata': {}}
+    schedules = [{
+        'PartitionKey': 'u1',
+        'RowKey': '1',
+        'event': json.dumps(event),
+        'runAt': (datetime.utcnow() - timedelta(minutes=1)).isoformat(),
+        'cron': ''
+    }]
+    sent = {}
+    mod = load_worker(monkeypatch, schedules, sent)
+    mod.main(None)
+    assert sent['messages'][0]['type'] == 't'
+    assert ('u1', '1') in sent['deleted']


### PR DESCRIPTION
## Summary
- implement HTTP `Scheduler` function for scheduling events
- store schedules in Azure Table Storage
- create `ScheduleWorker` timer function to publish due events
- document scheduler API
- test scheduler creation and worker logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683b5e441e50832ea17db4ccead040b7