### PR TITLE
Extend UserMessenger to relay chat responses

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,9 +60,9 @@ ensured to appear under the `metadata` key.
 
 ### UserMessenger function
 
-The `UserMessenger` Azure Function listens to the Service Bus queue for events of type `user.message`. When such an event is processed it will forward the message to the user. If no notification endpoint is configured (via the `NOTIFY_URL` environment variable) the message is logged instead.
+The `UserMessenger` Azure Function listens to the Service Bus queue for events of type `user.message` and `llm.chat.response`. When such an event is processed it forwards the text to the user. If no notification endpoint is configured (via the `NOTIFY_URL` environment variable) the text is logged instead.
 
-This allows the platform to acknowledge incoming chat messages before the LLM generates a response. Downstream services can also listen for `llm.chat.response` events to notify the user when a reply is available.
+This allows the platform to acknowledge incoming chat messages before the LLM generates a response and then deliver the assistant's reply once it is available.
 
 ## ChatResponder function
 

--- a/tests/test_user_messenger.py
+++ b/tests/test_user_messenger.py
@@ -75,3 +75,21 @@ def test_user_message_event(monkeypatch):
     module.main(msg)
     assert captured['url'] == 'http://notify'
     assert captured['json'] == {'user_id': 'u', 'message': 'hi'}
+
+
+def test_chat_response_event(monkeypatch):
+    os.environ['NOTIFY_URL'] = 'http://notify'
+    captured = {}
+    module, SBMessage = load_user_messenger(monkeypatch, captured)
+
+    event = {
+        'timestamp': '2023-01-01T00:00:00Z',
+        'source': 'ChatResponder',
+        'type': 'llm.chat.response',
+        'userID': 'u',
+        'metadata': {'reply': 'ok'}
+    }
+    msg = SBMessage(json.dumps(event))
+    module.main(msg)
+    assert captured['url'] == 'http://notify'
+    assert captured['json'] == {'user_id': 'u', 'message': 'ok'}


### PR DESCRIPTION
## Summary
- forward `llm.chat.response` events through UserMessenger
- note new behavior in README
- test that chat responses are forwarded

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683b5ee1f254832e89c42cec6a02979a