### PR TITLE
Provision schedule table with Pulumi

### DIFF
--- a/azure-function/Scheduler/__init__.py
+++ b/azure-function/Scheduler/__init__.py
@@ -14,7 +14,6 @@ SCHEDULE_TABLE = os.environ.get("SCHEDULE_TABLE", "schedules")
 
 service = TableServiceClient.from_connection_string(STORAGE_CONN)
 _table = service.get_table_client(SCHEDULE_TABLE)
-_table.create_table_if_not_exists()
 
 
 def main(req: func.HttpRequest) -> func.HttpResponse:

--- a/infra/index.ts
+++ b/infra/index.ts
@@ -39,6 +39,14 @@ const storage = new azure.storage.StorageAccount("funcsa", {
   kind: azure.storage.Kind.StorageV2,
 });
 
+// Table for scheduled events
+const scheduleTableName = "schedules";
+const scheduleTable = new azure.storage.Table("schedule-table", {
+  resourceGroupName: resourceGroup.name,
+  accountName: storage.name,
+  tableName: scheduleTableName,
+});
+
 const storageKeys = pulumi
   .all([resourceGroup.name, storage.name])
   .apply(([resourceGroupName, accountName]) =>
@@ -83,6 +91,8 @@ const funcApp = new azure.web.WebApp("event-function", {
       { name: "AzureWebJobsStorage", value: storageConnectionString },
       { name: "FUNCTIONS_EXTENSION_VERSION", value: "~4" },
       { name: "FUNCTIONS_WORKER_RUNTIME", value: "python" },
+      { name: "STORAGE_CONNECTION", value: storageConnectionString },
+      { name: "SCHEDULE_TABLE", value: scheduleTableName },
       {
         name: "SERVICEBUS_CONNECTION",
         value: sendKeys.primaryConnectionString,


### PR DESCRIPTION
## Summary
- create a pre-provisioned `schedules` table in Pulumi
- expose table info and connection string to the Function App
- drop runtime table creation from `Scheduler`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683b60208b78832e8d2ac40452b48e9b