### PR TITLE
Add OPENAI_API_KEY check to ChatResponder

### DIFF
--- a/azure-function/ChatResponder/__init__.py
+++ b/azure-function/ChatResponder/__init__.py
@@ -11,6 +11,7 @@ from events import Event, LLMChatEvent
 
 SERVICEBUS_CONN = os.environ.get("SERVICEBUS_CONNECTION")
 SERVICEBUS_QUEUE = os.environ.get("SERVICEBUS_QUEUE")
+OPENAI_API_KEY = os.environ.get("OPENAI_API_KEY")
 OPENAI_MODEL = os.environ.get("OPENAI_MODEL", "gpt-3.5-turbo")
 
 missing = []
@@ -18,6 +19,8 @@ if not SERVICEBUS_CONN:
     missing.append("SERVICEBUS_CONNECTION")
 if not SERVICEBUS_QUEUE:
     missing.append("SERVICEBUS_QUEUE")
+if not OPENAI_API_KEY:
+    missing.append("OPENAI_API_KEY")
 if missing:
     logging.error("Missing required environment variable(s): %s", ", ".join(missing))
     raise RuntimeError("Azure Function misconfigured")

--- a/tests/test_chat_responder.py
+++ b/tests/test_chat_responder.py
@@ -3,6 +3,7 @@ import sys
 import json
 import types
 import importlib.util
+import pytest
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
@@ -72,6 +73,7 @@ def test_openai_model_env(monkeypatch):
     os.environ['SERVICEBUS_CONNECTION'] = 'endpoint'
     os.environ['SERVICEBUS_QUEUE'] = 'queue'
     os.environ['OPENAI_MODEL'] = 'test-model'
+    os.environ['OPENAI_API_KEY'] = 'sk-test'
 
     captured = {}
     module, SBMessage = load_chat_responder(monkeypatch, captured)
@@ -87,3 +89,13 @@ def test_openai_model_env(monkeypatch):
     module.main(msg)
 
     assert captured['model'] == 'test-model'
+
+
+def test_missing_api_key(monkeypatch):
+    os.environ['SERVICEBUS_CONNECTION'] = 'endpoint'
+    os.environ['SERVICEBUS_QUEUE'] = 'queue'
+    if 'OPENAI_API_KEY' in os.environ:
+        del os.environ['OPENAI_API_KEY']
+
+    with pytest.raises(RuntimeError):
+        load_chat_responder(monkeypatch, {})


### PR DESCRIPTION
## Summary
- validate OPENAI_API_KEY when ChatResponder starts
- update ChatResponder test to set API key
- test error raised when API key missing

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683b6862848c832ea26ecabdccc58c4e