### PR TITLE
Add OPENAI_API_KEY propagation

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,3 +27,4 @@ jobs:
           ARM_CLIENT_SECRET: ${{ secrets.ARM_CLIENT_SECRET }}
           ARM_TENANT_ID: ${{ secrets.ARM_TENANT_ID }}
           ARM_SUBSCRIPTION_ID: ${{ secrets.ARM_SUBSCRIPTION_ID }}
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}

--- a/README.md
+++ b/README.md
@@ -138,7 +138,9 @@ assistant reply:
    func azure functionapp publish event-function
    ```
 
-Ensure `OPENAI_API_KEY` is configured on the Function App before publishing.
+If deploying via the provided GitHub Actions workflow, set an `OPENAI_API_KEY` secret
+so Pulumi can configure it on the Function App. Otherwise make sure the key is set
+manually before publishing.
 
 ## Function Configuration
 

--- a/azure-function/ChatResponder/__init__.py
+++ b/azure-function/ChatResponder/__init__.py
@@ -11,6 +11,7 @@ from events import Event, LLMChatEvent
 
 SERVICEBUS_CONN = os.environ.get("SERVICEBUS_CONNECTION")
 SERVICEBUS_QUEUE = os.environ.get("SERVICEBUS_QUEUE")
+OPENAI_API_KEY = os.environ.get("OPENAI_API_KEY")
 OPENAI_MODEL = os.environ.get("OPENAI_MODEL", "gpt-3.5-turbo")
 
 missing = []
@@ -18,6 +19,8 @@ if not SERVICEBUS_CONN:
     missing.append("SERVICEBUS_CONNECTION")
 if not SERVICEBUS_QUEUE:
     missing.append("SERVICEBUS_QUEUE")
+if not OPENAI_API_KEY:
+    missing.append("OPENAI_API_KEY")
 if missing:
     logging.error("Missing required environment variable(s): %s", ", ".join(missing))
     raise RuntimeError("Azure Function misconfigured")

--- a/infra/index.ts
+++ b/infra/index.ts
@@ -4,6 +4,11 @@ import * as azure from "@pulumi/azure-native";
 const config = new pulumi.Config();
 const location = config.get("location") || "centralindia";
 
+const openaiApiKey = process.env.OPENAI_API_KEY;
+if (!openaiApiKey) {
+  throw new Error("OPENAI_API_KEY must be set when deploying");
+}
+
 const resourceGroup = new azure.resources.ResourceGroup("lightning", {
   resourceGroupName: "lightning",
   location,
@@ -111,6 +116,7 @@ const funcApp = new azure.web.WebApp("event-function", {
         value: sendKeys.primaryConnectionString,
       },
       { name: "SERVICEBUS_QUEUE", value: queue.name },
+      { name: "OPENAI_API_KEY", value: openaiApiKey },
       { name: "STORAGE_CONNECTION", value: storageConnectionString },
       { name: "SCHEDULE_TABLE", value: scheduleTable.name },
       { name: "REPO_TABLE", value: repoTable.name },

--- a/tests/test_chat_responder.py
+++ b/tests/test_chat_responder.py
@@ -3,6 +3,7 @@ import sys
 import json
 import types
 import importlib.util
+import pytest
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
 
@@ -72,6 +73,7 @@ def test_openai_model_env(monkeypatch):
     os.environ['SERVICEBUS_CONNECTION'] = 'endpoint'
     os.environ['SERVICEBUS_QUEUE'] = 'queue'
     os.environ['OPENAI_MODEL'] = 'test-model'
+    os.environ['OPENAI_API_KEY'] = 'sk-test'
 
     captured = {}
     module, SBMessage = load_chat_responder(monkeypatch, captured)
@@ -87,3 +89,13 @@ def test_openai_model_env(monkeypatch):
     module.main(msg)
 
     assert captured['model'] == 'test-model'
+
+
+def test_missing_api_key(monkeypatch):
+    os.environ['SERVICEBUS_CONNECTION'] = 'endpoint'
+    os.environ['SERVICEBUS_QUEUE'] = 'queue'
+    if 'OPENAI_API_KEY' in os.environ:
+        del os.environ['OPENAI_API_KEY']
+
+    with pytest.raises(RuntimeError):
+        load_chat_responder(monkeypatch, {})


### PR DESCRIPTION
## Summary
- push OPENAI_API_KEY from GitHub Actions into the function app
- document OPENAI_API_KEY secret usage in README
- require OPENAI_API_KEY when deploying with Pulumi

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683b6862848c832ea26ecabdccc58c4e