### PR TITLE
Ensure OPENAI key flows from GitHub to Azure

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -16,6 +16,11 @@ jobs:
       - name: Install dependencies
         run: pip install -r requirements.txt
         working-directory: infra
+      - name: Configure OpenAI key
+        run: pulumi config set openaiApiKey "$OPENAI_API_KEY" --secret
+        working-directory: infra
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
       - uses: pulumi/actions@v3
         with:
           command: up

--- a/README.md
+++ b/README.md
@@ -138,7 +138,9 @@ assistant reply:
    func azure functionapp publish event-function
    ```
 
-Ensure `OPENAI_API_KEY` is configured on the Function App before publishing.
+If deploying manually, ensure `OPENAI_API_KEY` is configured on the Function App
+before publishing. The GitHub Actions workflow reads the `OPENAI_API_KEY` secret
+and sets this application setting automatically when running Pulumi.
 
 ## Function Configuration
 
@@ -147,6 +149,8 @@ messaging:
 
 - `OPENAI_API_KEY` &mdash; API key used by the `ChatResponder` function when
   calling OpenAI.
+  When deploying with GitHub Actions, set this as the `OPENAI_API_KEY` secret
+  so the workflow can configure the Function App.
 - `OPENAI_MODEL` &mdash; model name for ChatResponder when calling OpenAI 
   (defaults to `gpt-3.5-turbo`).
 - `SERVICEBUS_CONNECTION` &mdash; connection string for the Service Bus

--- a/infra/__main__.py
+++ b/infra/__main__.py
@@ -3,6 +3,7 @@ from pulumi_azure_native import resources, servicebus, storage, web
 
 config = pulumi.Config()
 location = config.get("location") or "centralindia"
+openai_api_key = config.require_secret("openaiApiKey")
 
 # Resource group
 resource_group = resources.ResourceGroup(
@@ -109,6 +110,7 @@ func_app = web.WebApp(
             web.NameValuePairArgs(name="SERVICEBUS_CONNECTION", value=send_keys.primary_connection_string),
             web.NameValuePairArgs(name="SERVICEBUS_QUEUE", value=queue.name),
             web.NameValuePairArgs(name="REPO_TABLE", value=repo_table.name),
+            web.NameValuePairArgs(name="OPENAI_API_KEY", value=openai_api_key),
         ]
     ),
 )


### PR DESCRIPTION
## Summary
- read `openaiApiKey` from Pulumi config and expose it as `OPENAI_API_KEY` for the Function App
- configure the deployment workflow to set this Pulumi config from the `OPENAI_API_KEY` secret
- document the automatic secret propagation in the README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683b6c890834832e9fa4484ddf5e6638