### PR TITLE
Implement bearer token authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@ Deploying the infrastructure will create an Azure Function that exposes an HTTP 
 
 ### POST /api/events
 
-Include a header `X-User-ID` identifying the user on whose behalf the event was
-generated. Send a JSON body describing the event:
+Authenticate requests with a bearer token in the `Authorization` header.
+The token must be signed using the key provided in `JWT_SIGNING_KEY` and
+identifies the user. Send a JSON body describing the event:
 
 ```json
 {
@@ -25,9 +26,9 @@ The function validates the data and publishes it to the Service Bus queue. The `
 
 ### POST /api/schedule
 
-Schedule an event for future delivery. Provide the `X-User-ID` header and a JSON
-body containing the event payload and either a one-time `timestamp` or a `cron`
-expression:
+Schedule an event for future delivery. Provide the same bearer token in the
+`Authorization` header and a JSON body containing the event payload and either
+a one-time `timestamp` or a `cron` expression:
 
 ```json
 {
@@ -102,7 +103,7 @@ Send a chat event via the HTTP endpoint:
 
 ```bash
 curl -X POST \
-  -H "X-User-ID: abc123" \
+  -H "Authorization: Bearer <token>" \
   -H "Content-Type: application/json" \
   -d @event.json \
   https://<function-app>.azurewebsites.net/api/events
@@ -154,6 +155,7 @@ messaging:
 - `SERVICEBUS_QUEUE` &mdash; queue name for publishing and receiving events.
 - `NOTIFY_URL` &mdash; endpoint that `UserMessenger` calls to deliver messages
   to the chat client.
+- `JWT_SIGNING_KEY` &mdash; HMAC key used to validate bearer tokens.
 
 Set these values in your deployment environment or in a local `.env` file when
 testing the functions locally.
@@ -176,7 +178,8 @@ Functions Core Tools) or through a `.env` file in the repository root.
     "OPENAI_MODEL": "gpt-3.5-turbo",
     "SERVICEBUS_CONNECTION": "<connection-string>",
     "SERVICEBUS_QUEUE": "chat-events",
-    "NOTIFY_URL": "http://localhost:8000/notify"
+    "NOTIFY_URL": "http://localhost:8000/notify",
+    "JWT_SIGNING_KEY": "secret"
   }
 }
 ```
@@ -189,6 +192,7 @@ OPENAI_MODEL=gpt-3.5-turbo
 SERVICEBUS_CONNECTION=<connection-string>
 SERVICEBUS_QUEUE=chat-events
 NOTIFY_URL=http://localhost:8000/notify
+JWT_SIGNING_KEY=secret
 ```
 
 Start the functions locally from the `azure-function` directory:

--- a/azure-function/PutEvent/__init__.py
+++ b/azure-function/PutEvent/__init__.py
@@ -7,6 +7,7 @@ import azure.functions as func
 from azure.servicebus import ServiceBusClient, ServiceBusMessage
 
 from events import Event
+from auth import verify_token
 
 SERVICEBUS_CONN = os.environ.get("SERVICEBUS_CONNECTION")
 SERVICEBUS_QUEUE = os.environ.get("SERVICEBUS_QUEUE")
@@ -31,9 +32,10 @@ def main(req: func.HttpRequest) -> func.HttpResponse:
     except ValueError:
         return func.HttpResponse("Invalid JSON", status_code=400)
 
-    user_id = req.headers.get("x-user-id")
-    if not user_id:
-        return func.HttpResponse("Missing user ID", status_code=400)
+    try:
+        user_id = verify_token(req.headers.get("Authorization"))
+    except Exception:
+        return func.HttpResponse("Unauthorized", status_code=401)
     data["userID"] = user_id
 
     try:

--- a/azure-function/RegisterRepo/__init__.py
+++ b/azure-function/RegisterRepo/__init__.py
@@ -4,6 +4,7 @@ import logging
 
 import azure.functions as func
 from azure.data.tables import TableServiceClient
+from auth import verify_token
 
 STORAGE_CONN = os.environ.get("STORAGE_CONNECTION")
 REPO_TABLE = os.environ.get("REPO_TABLE", "repos")
@@ -19,9 +20,10 @@ def main(req: func.HttpRequest) -> func.HttpResponse:
     except ValueError:
         return func.HttpResponse("Invalid JSON", status_code=400)
 
-    user_id = req.headers.get("x-user-id")
-    if not user_id:
-        return func.HttpResponse("Missing user ID", status_code=400)
+    try:
+        user_id = verify_token(req.headers.get("Authorization"))
+    except Exception:
+        return func.HttpResponse("Unauthorized", status_code=401)
 
     repo = data.get("repo")
     if not repo:

--- a/azure-function/auth.py
+++ b/azure-function/auth.py
@@ -1,0 +1,23 @@
+import os
+import jwt
+
+
+def verify_token(auth_header: str) -> str:
+    """Validate a bearer token and return the user ID."""
+    key = os.environ.get("JWT_SIGNING_KEY")
+    if not key:
+        raise RuntimeError("JWT_SIGNING_KEY not configured")
+
+    if not auth_header or not auth_header.startswith("Bearer "):
+        raise ValueError("Missing bearer token")
+
+    token = auth_header.split(" ", 1)[1]
+    try:
+        claims = jwt.decode(token, key, algorithms=["HS256"])
+    except Exception as e:
+        raise ValueError("Invalid token") from e
+
+    user_id = claims.get("sub") or claims.get("user_id") or claims.get("userID")
+    if not user_id:
+        raise ValueError("user id claim missing")
+    return user_id

--- a/azure-function/requirements.txt
+++ b/azure-function/requirements.txt
@@ -4,3 +4,4 @@ openai
 requests
 azure-data-tables
 croniter
+pyjwt


### PR DESCRIPTION
## Summary
- add `verify_token` helper using pyjwt
- update PutEvent, Scheduler, and RegisterRepo to use bearer tokens
- require `pyjwt` dependency for functions
- adjust tests for new auth and add coverage for 401 cases
- document bearer authentication in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683b6c141d8c832ea277cd09e118f238