### PR TITLE
Integrate Azure Container Instances for worker tasks

### DIFF
--- a/azure-function/WorkerTaskRunner/__init__.py
+++ b/azure-function/WorkerTaskRunner/__init__.py
@@ -1,11 +1,20 @@
 import json
 import logging
 import os
-import shutil
-import subprocess
-import tempfile
-from datetime import datetime
 import uuid
+
+from azure.identity import DefaultAzureCredential
+from azure.mgmt.containerinstance import ContainerInstanceManagementClient
+from azure.mgmt.containerinstance.models import (
+    Container,
+    ContainerGroup,
+    ContainerGroupRestartPolicy,
+    EnvironmentVariable,
+    OperatingSystemTypes,
+    ResourceRequests,
+    ResourceRequirements,
+)
+from datetime import datetime
 
 import azure.functions as func
 from azure.data.tables import TableServiceClient
@@ -17,10 +26,20 @@ STORAGE_CONN = os.environ.get("STORAGE_CONNECTION")
 REPO_TABLE = os.environ.get("REPO_TABLE", "repos")
 SERVICEBUS_CONN = os.environ.get("SERVICEBUS_CONNECTION")
 SERVICEBUS_QUEUE = os.environ.get("SERVICEBUS_QUEUE")
+ACI_RESOURCE_GROUP = os.environ.get("ACI_RESOURCE_GROUP")
+ACI_SUBSCRIPTION_ID = os.environ.get("ACI_SUBSCRIPTION_ID")
+ACI_REGION = os.environ.get("ACI_REGION", "centralindia")
 
 _table_service = TableServiceClient.from_connection_string(STORAGE_CONN)
 _repo_table = _table_service.get_table_client(REPO_TABLE)
 _sb_client = ServiceBusClient.from_connection_string(SERVICEBUS_CONN)
+_credential = DefaultAzureCredential()
+_aci_client = None
+if ACI_RESOURCE_GROUP and ACI_SUBSCRIPTION_ID:
+    _aci_client = ContainerInstanceManagementClient(_credential, ACI_SUBSCRIPTION_ID)
+
+
+WORKER_IMAGE = os.environ.get("WORKER_IMAGE", "worker-task")
 
 
 def main(msg: func.ServiceBusMessage) -> None:
@@ -41,28 +60,35 @@ def main(msg: func.ServiceBusMessage) -> None:
             logging.error("Repo not found for user %s: %s", event.user_id, e)
             return
 
-    workdir = tempfile.mkdtemp(prefix="repo")
-    image_tag = f"task-{event.user_id}-{uuid.uuid4().hex[:8]}"
+    if repo and not event.repo_url:
+        event.repo_url = repo
+
     result = ""
     try:
-        subprocess.run(["git", "clone", repo, workdir], check=True)
-        subprocess.run(["docker", "build", "-t", image_tag, workdir], check=True)
-        env = os.environ.copy()
-        env.update(
-            {
-                "SERVICEBUS_CONNECTION": SERVICEBUS_CONN or "",
-                "SERVICEBUS_QUEUE": SERVICEBUS_QUEUE or "",
-                "WORKER_EVENT": json.dumps(event.to_dict()),
-            }
+        if not _aci_client:
+            raise RuntimeError("ACI client not configured")
+        env_list = [
+            EnvironmentVariable(name="SERVICEBUS_CONNECTION", value=SERVICEBUS_CONN or ""),
+            EnvironmentVariable(name="SERVICEBUS_QUEUE", value=SERVICEBUS_QUEUE or ""),
+            EnvironmentVariable(name="WORKER_EVENT", value=json.dumps(event.to_dict())),
+        ]
+        container = Container(
+            name="worker",
+            image=WORKER_IMAGE,
+            resources=ResourceRequirements(requests=ResourceRequests(cpu=1.0, memory_in_gb=1.0)),
+            environment_variables=env_list,
         )
-        subprocess.run(
-            ["docker", "run", "-d", "--rm", image_tag], env=env, check=True
+        group = ContainerGroup(
+            location=ACI_REGION,
+            os_type=OperatingSystemTypes.LINUX,
+            restart_policy=ContainerGroupRestartPolicy.NEVER,
+            containers=[container],
         )
+        group_name = f"worker-{uuid.uuid4().hex[:8]}"
+        _aci_client.container_groups.begin_create_or_update(ACI_RESOURCE_GROUP, group_name, group).result()
         result = "started"
-    except subprocess.CalledProcessError as e:
+    except Exception as e:
         result = f"error: {e}"
-    finally:
-        shutil.rmtree(workdir, ignore_errors=True)
 
     out_event = Event(
         timestamp=datetime.utcnow(),

--- a/azure-function/requirements.txt
+++ b/azure-function/requirements.txt
@@ -4,3 +4,5 @@ openai
 requests
 azure-data-tables
 croniter
+azure-identity
+azure-mgmt-containerinstance

--- a/infra/__main__.py
+++ b/infra/__main__.py
@@ -1,5 +1,12 @@
 import pulumi
-from pulumi_azure_native import resources, servicebus, storage, web
+from pulumi_azure_native import (
+    resources,
+    servicebus,
+    storage,
+    web,
+    authorization,
+)
+from pulumi_azure_native.authorization import get_client_config, RoleAssignment
 
 config = pulumi.Config()
 location = config.get("location") or "centralindia"
@@ -94,11 +101,15 @@ send_keys = servicebus.list_queue_keys_output(
 )
 
 # Function App
+client_config = get_client_config()
+subscription_id = client_config.subscription_id
+
 func_app = web.WebApp(
     "event-function",
     resource_group_name=resource_group.name,
     server_farm_id=app_service_plan.id,
     kind="FunctionApp",
+    identity=web.ManagedServiceIdentityArgs(type=web.ManagedServiceIdentityType.SYSTEM_ASSIGNED),
     site_config=web.SiteConfigArgs(
         app_settings=[
             web.NameValuePairArgs(name="AzureWebJobsStorage", value=storage_connection_string),
@@ -109,8 +120,19 @@ func_app = web.WebApp(
             web.NameValuePairArgs(name="SERVICEBUS_CONNECTION", value=send_keys.primary_connection_string),
             web.NameValuePairArgs(name="SERVICEBUS_QUEUE", value=queue.name),
             web.NameValuePairArgs(name="REPO_TABLE", value=repo_table.name),
+            web.NameValuePairArgs(name="ACI_RESOURCE_GROUP", value=resource_group.name),
+            web.NameValuePairArgs(name="ACI_SUBSCRIPTION_ID", value=subscription_id),
+            web.NameValuePairArgs(name="ACI_REGION", value=location),
         ]
     ),
+)
+
+aci_role = RoleAssignment(
+    "aci-contributor",
+    principal_id=func_app.identity.principal_id,
+    principal_type="ServicePrincipal",
+    role_definition_id=f"/subscriptions/{subscription_id}/providers/Microsoft.Authorization/roleDefinitions/b24988ac-6180-42a0-ab88-20f7382dd24c",
+    scope=resource_group.id,
 )
 
 pulumi.export(


### PR DESCRIPTION
## Summary
- give the Function App a managed identity and permission to create containers
- expose ACI configuration to the worker Function through app settings
- launch worker tasks in Azure Container Instances instead of local Docker
- include required Azure SDK packages for container instances

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683b663669dc832ea6c67097f49a5b55