### PR TITLE
Switch chat client auth to bearer token

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,7 @@ SERVICEBUS_CONNECTION=<connection-string>
 SERVICEBUS_QUEUE=chat-events
 NOTIFY_URL=http://localhost:8000/notify
 JWT_SIGNING_KEY=secret
+AUTH_TOKEN=<jwt-token>
 ```
 
 Start the functions locally from the `azure-function` directory:
@@ -213,7 +214,9 @@ chainlit run chat_client/chainlit_app.py
 ```
 
 Set `EVENT_API_URL` to `http://localhost:7071/api/events` so the client sends
-events to your local Function App.
+events to your local Function App. Provide your bearer token in the
+`AUTH_TOKEN` environment variable so the client can authenticate with the Event
+API.
 
 ## Chainlit client
 
@@ -223,7 +226,8 @@ Run the interactive chat client using [Chainlit](https://github.com/Chainlit/cha
 chainlit run chat_client/chainlit_app.py
 ```
 
-`EVENT_API_URL` should point to the `/api/events` endpoint of the Azure Function.
-Configure `NOTIFY_URL` for the Azure Functions as `http://<chainlit_host>/notify`
-so `UserMessenger` can forward messages back to the client.
+`EVENT_API_URL` should point to the `/api/events` endpoint of the Azure
+Function. Configure `AUTH_TOKEN` with your JWT and set `NOTIFY_URL` for the
+Azure Functions as `http://<chainlit_host>/notify` so `UserMessenger` can
+forward messages back to the client.
 

--- a/chat_client/chainlit_app.py
+++ b/chat_client/chainlit_app.py
@@ -8,6 +8,7 @@ from fastapi import HTTPException
 from chainlit.server import app as fastapi_app
 
 EVENT_API_URL = os.environ.get("EVENT_API_URL")
+AUTH_TOKEN = os.environ.get("AUTH_TOKEN")
 
 
 @cl.on_message
@@ -15,6 +16,9 @@ async def on_message(message: cl.Message):
     """Handle incoming user message and queue a chat event."""
     if not EVENT_API_URL:
         await cl.Message(content="EVENT_API_URL not configured", author="system").send()
+        return
+    if not AUTH_TOKEN:
+        await cl.Message(content="AUTH_TOKEN not configured", author="system").send()
         return
 
     event = {
@@ -26,7 +30,7 @@ async def on_message(message: cl.Message):
         },
     }
 
-    headers = {"X-User-ID": message.author}
+    headers = {"Authorization": f"Bearer {AUTH_TOKEN}"}
     try:
         resp = requests.post(EVENT_API_URL, json=event, headers=headers)
         if not 200 <= resp.status_code < 300:

--- a/tests/test_chainlit_app.py
+++ b/tests/test_chainlit_app.py
@@ -1,0 +1,84 @@
+import os
+import sys
+import types
+import importlib.util
+import asyncio
+
+
+def load_chainlit_app(monkeypatch, capture):
+    # Stub chainlit
+    cl_mod = types.ModuleType('chainlit')
+    handlers = {}
+
+    def on_message(func):
+        handlers['handler'] = func
+        return func
+
+    class Msg:
+        def __init__(self, content, author='user'):
+            self.content = content
+            self.author = author
+        async def send(self):
+            capture.setdefault('sent', []).append(self)
+
+    cl_mod.on_message = on_message
+    cl_mod.Message = Msg
+    app_obj = types.SimpleNamespace(post=lambda path: (lambda f: f))
+    cl_mod.server = types.SimpleNamespace(app=app_obj)
+    monkeypatch.setitem(sys.modules, 'chainlit', cl_mod)
+    monkeypatch.setitem(sys.modules, 'chainlit.server', types.SimpleNamespace(app=app_obj))
+
+    # Stub fastapi
+    fastapi_mod = types.ModuleType('fastapi')
+    class HTTPException(Exception):
+        def __init__(self, status_code, detail=None):
+            self.status_code = status_code
+            self.detail = detail
+    fastapi_mod.HTTPException = HTTPException
+    monkeypatch.setitem(sys.modules, 'fastapi', fastapi_mod)
+
+    # Stub requests
+    req_mod = types.ModuleType('requests')
+    def post(url, json=None, headers=None):
+        capture['url'] = url
+        capture['json'] = json
+        capture['headers'] = headers
+        return types.SimpleNamespace(status_code=200, text='')
+    req_mod.post = post
+    monkeypatch.setitem(sys.modules, 'requests', req_mod)
+
+    # Load module
+    spec = importlib.util.spec_from_file_location(
+        'chat_client.chainlit_app',
+        os.path.join(os.path.dirname(__file__), '..', 'chat_client', 'chainlit_app.py')
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules['chat_client.chainlit_app'] = module
+    spec.loader.exec_module(module)
+    return handlers['handler'], module
+
+
+async def run_handler(handler, content='hi', author='u'):
+    msg = sys.modules['chainlit'].Message(content, author)
+    await handler(msg)
+
+
+def test_authorization_header(monkeypatch):
+    monkeypatch.setenv('EVENT_API_URL', 'http://api')
+    monkeypatch.setenv('AUTH_TOKEN', 'tok')
+    capture = {}
+    handler, module = load_chainlit_app(monkeypatch, capture)
+    asyncio.run(run_handler(handler))
+    assert capture['headers']['Authorization'] == 'Bearer tok'
+    assert 'X-User-ID' not in capture['headers']
+
+
+def test_missing_token(monkeypatch):
+    monkeypatch.setenv('EVENT_API_URL', 'http://api')
+    monkeypatch.delenv('AUTH_TOKEN', raising=False)
+    capture = {}
+    handler, module = load_chainlit_app(monkeypatch, capture)
+    asyncio.run(run_handler(handler))
+    assert capture['sent'][0].content == 'AUTH_TOKEN not configured'
+
+


### PR DESCRIPTION
## Summary
- add `AUTH_TOKEN` environment variable for chat client
- send JWT using `Authorization` header in Chainlit app
- document new auth header usage and env var
- test Chainlit client auth header

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683b7198cf00832eb94064234ed69a6d