### PR TITLE
Add strict LLMChatEvent validation

### DIFF
--- a/events/__init__.py
+++ b/events/__init__.py
@@ -67,6 +67,11 @@ class LLMChatEvent(Event):
         msgs = base.metadata.get("messages")
         if not msgs:
             raise ValueError("metadata.messages required")
+        if not isinstance(msgs, list):
+            raise ValueError("metadata.messages must be a list")
+        for msg in msgs:
+            if not isinstance(msg, dict) or "role" not in msg or "content" not in msg:
+                raise ValueError("invalid message entry")
         return cls(**asdict(base), messages=msgs)
 
     def to_dict(self) -> Dict[str, Any]:

--- a/tests/test_llm_chat_event.py
+++ b/tests/test_llm_chat_event.py
@@ -19,6 +19,46 @@ def test_llmchat_missing_messages():
         LLMChatEvent.from_dict(data)
 
 
+def test_llmchat_invalid_messages_type():
+    data = {
+        "timestamp": datetime.now().isoformat(),
+        "source": "s",
+        "type": "llm.chat",
+        "userID": "u1",
+        "metadata": {"messages": "notalist"},
+    }
+    with pytest.raises(ValueError):
+        LLMChatEvent.from_dict(data)
+
+
+def test_llmchat_message_missing_role():
+    now = datetime.now()
+    msgs = [{"content": "hi"}]
+    data = {
+        "timestamp": now.isoformat(),
+        "source": "s",
+        "type": "llm.chat",
+        "userID": "u1",
+        "metadata": {"messages": msgs},
+    }
+    with pytest.raises(ValueError):
+        LLMChatEvent.from_dict(data)
+
+
+def test_llmchat_message_missing_content():
+    now = datetime.now()
+    msgs = [{"role": "user"}]
+    data = {
+        "timestamp": now.isoformat(),
+        "source": "s",
+        "type": "llm.chat",
+        "userID": "u1",
+        "metadata": {"messages": msgs},
+    }
+    with pytest.raises(ValueError):
+        LLMChatEvent.from_dict(data)
+
+
 def test_llmchat_round_trip():
     now = datetime.now()
     msgs = [{"role": "user", "content": "hi"}]


### PR DESCRIPTION
## Summary
- validate each LLMChatEvent message has `role` and `content`
- test invalid structures in metadata.messages

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683b71b984b8832e89c791b70791f4a0