### PR TITLE
Add initial dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -232,3 +232,16 @@ Function. Configure `AUTH_TOKEN` with your JWT and set `NOTIFY_URL` for the
 Azure Functions as `http://<chainlit_host>/notify` so `UserMessenger` can
 forward messages back to the client.
 
+## Dashboard
+
+A simple FastAPI dashboard is located in the `dashboard/` directory. It allows
+logging in and submitting events to the backend. Launch it with:
+
+```bash
+uvicorn dashboard.app:app --reload
+```
+
+Set `API_BASE` to the base URL of your Azure Functions (defaults to
+`http://localhost:7071/api`). If `AUTH_TOKEN` is provided the dashboard will use
+it for outgoing requests; otherwise use the `/login` page to obtain a token.
+

--- a/dashboard/app.py
+++ b/dashboard/app.py
@@ -1,0 +1,67 @@
+from fastapi import FastAPI, HTTPException, Depends
+from fastapi.templating import Jinja2Templates
+from fastapi.responses import HTMLResponse, RedirectResponse
+from fastapi.staticfiles import StaticFiles
+from pydantic import BaseModel
+from datetime import datetime
+from starlette.requests import Request
+import os
+import requests
+
+API_BASE = os.environ.get("API_BASE", "http://localhost:7071/api")
+AUTH_TOKEN = os.environ.get("AUTH_TOKEN")
+
+templates = Jinja2Templates(directory=os.path.join(os.path.dirname(__file__), "templates"))
+app = FastAPI()
+app.mount("/static", StaticFiles(directory=os.path.join(os.path.dirname(__file__), "static")), name="static")
+
+class LoginForm(BaseModel):
+    username: str
+    password: str
+
+
+from starlette.requests import Request
+
+
+@app.get("/", response_class=HTMLResponse)
+async def index(request: Request):
+    return templates.TemplateResponse("index.html", {"request": request})
+
+
+@app.post("/login")
+async def login(form: LoginForm):
+    resp = requests.post(f"{API_BASE}/userauth/login", json=form.dict())
+    if resp.status_code != 200:
+        raise HTTPException(status_code=resp.status_code, detail=resp.text)
+    token = resp.json().get("token")
+    response = RedirectResponse("/", status_code=302)
+    if token:
+        response.set_cookie("token", token, httponly=True)
+    return response
+
+
+def _get_token(token: str = None):
+    return token or AUTH_TOKEN
+
+
+class EventIn(BaseModel):
+    type: str
+    metadata: dict
+
+
+@app.post("/events")
+async def create_event(event: EventIn, token: str = Depends(_get_token)):
+    if not token:
+        raise HTTPException(status_code=401, detail="missing token")
+    payload = {
+        "timestamp": datetime.utcnow().isoformat(),
+        "source": "dashboard",
+        "type": event.type,
+        "metadata": event.metadata,
+    }
+    headers = {"Authorization": f"Bearer {token}"}
+    resp = requests.post(f"{API_BASE}/events", json=payload, headers=headers)
+    if resp.status_code >= 300:
+        raise HTTPException(status_code=resp.status_code, detail=resp.text)
+    return {"status": "queued"}
+

--- a/dashboard/templates/index.html
+++ b/dashboard/templates/index.html
@@ -1,0 +1,8 @@
+<!DOCTYPE html>
+<html>
+<head><title>Dashboard</title></head>
+<body>
+<h1>Lightening Dashboard</h1>
+<p>Welcome to the dashboard.</p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add FastAPI dashboard skeleton with login and event creation
- document how to run the dashboard in README

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_683b6f0e6a90832e9be4c09fc1bda446