### PR TITLE
Enforce token expiry and verify issuer

### DIFF
--- a/azure-function/auth.py
+++ b/azure-function/auth.py
@@ -12,10 +12,15 @@ def verify_token(auth_header: str) -> str:
         raise ValueError("Missing bearer token")
 
     token = auth_header.split(" ", 1)[1]
+    options = {"require": ["exp"]}
     try:
-        claims = jwt.decode(token, key, algorithms=["HS256"])
+        claims = jwt.decode(token, key, algorithms=["HS256"], options=options)
     except Exception as e:
         raise ValueError("Invalid token") from e
+
+    issuer = os.environ.get("ISSUER")
+    if issuer and claims.get("iss") != issuer:
+        raise ValueError("Invalid issuer")
 
     user_id = claims.get("sub") or claims.get("user_id") or claims.get("userID")
     if not user_id:

--- a/azure-function/requirements.txt
+++ b/azure-function/requirements.txt
@@ -6,4 +6,4 @@ azure-data-tables
 croniter
 azure-identity
 azure-mgmt-containerinstance
-pyjwt
+PyJWT

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,0 +1,35 @@
+import os
+import sys
+import time
+import importlib.util
+import pytest
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "..")))
+
+import jwt
+
+
+def load_auth():
+    path = os.path.join(os.path.dirname(__file__), "..", "azure-function", "auth.py")
+    spec = importlib.util.spec_from_file_location("auth", path)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules['auth'] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_expired_token(monkeypatch):
+    os.environ['JWT_SIGNING_KEY'] = 'k'
+    token = jwt.encode({'sub': 'u', 'exp': time.time() - 10}, 'k')
+    auth = load_auth()
+    with pytest.raises(ValueError):
+        auth.verify_token('Bearer ' + token)
+
+
+def test_invalid_issuer(monkeypatch):
+    os.environ['JWT_SIGNING_KEY'] = 'k'
+    os.environ['ISSUER'] = 'good'
+    token = jwt.encode({'sub': 'u', 'exp': time.time() + 60, 'iss': 'bad'}, 'k')
+    auth = load_auth()
+    with pytest.raises(ValueError):
+        auth.verify_token('Bearer ' + token)


### PR DESCRIPTION
## Summary
- enforce `exp` claim in JWT tokens and optionally verify issuer
- depend on PyJWT instead of a custom `jwt` module
- add tests for expired tokens and invalid issuers

## Testing
- ❌ `pytest -q` (fails: ModuleNotFoundError: No module named 'jwt')

This environment doesn't have network access after setup, so Codex couldn't run certain commands. Consider configuring a setup script in your Codex environment to install dependencies.

------
https://chatgpt.com/codex/tasks/task_e_683b7191df74832ea5e4d3bc3e1da32d