### PR TITLE
Add agents directory for worker tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,3 +289,10 @@ Set `API_BASE` to the base URL of your Azure Functions (defaults to
 `http://localhost:7071/api`). If `AUTH_TOKEN` is provided the dashboard will use
 it for outgoing requests; otherwise use the `/login` page to obtain a token.
 
+
+## Worker Agents
+
+The `agents/` directory contains agent implementations that the worker container can
+invoke to process tasks. Each agent registers itself in `agents.AGENT_REGISTRY`
+and exposes a `run()` method used to handle the commands from a
+`WorkerTaskEvent`.

--- a/agents/__init__.py
+++ b/agents/__init__.py
@@ -1,0 +1,28 @@
+"""Agents available to run worker tasks."""
+
+from typing import Dict, List
+
+
+class Agent:
+    """Base class for task agents."""
+
+    name: str = "base"
+
+    def run(self, commands: List[str]) -> str:
+        """Execute the provided commands and return a result string."""
+        raise NotImplementedError()
+
+
+AGENT_REGISTRY: Dict[str, Agent] = {}
+
+
+def register(agent_cls: type) -> type:
+    """Class decorator to register an agent in the registry."""
+    instance = agent_cls()
+    if not isinstance(instance, Agent):
+        raise TypeError("agent_cls must inherit from Agent")
+    AGENT_REGISTRY[instance.name] = instance
+    return agent_cls
+
+
+from . import echo_agent  # noqa: F401  # register built-in agents

--- a/agents/echo_agent.py
+++ b/agents/echo_agent.py
@@ -1,0 +1,13 @@
+from typing import List
+
+from . import Agent, register
+
+
+@register
+class EchoAgent(Agent):
+    """Simple agent that echoes the received commands."""
+
+    name = "echo"
+
+    def run(self, commands: List[str]) -> str:
+        return "\n".join(commands)

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -1,0 +1,11 @@
+import sys, os
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
+from agents import AGENT_REGISTRY
+
+
+def test_echo_agent_registry():
+    assert 'echo' in AGENT_REGISTRY
+    agent = AGENT_REGISTRY['echo']
+    result = agent.run(['hi', 'there'])
+    assert result == 'hi\nthere'


### PR DESCRIPTION
## Summary
- introduce `agents` package with a base agent class and registry
- add a simple `EchoAgent` example
- test agent registration
- document new worker agent directory in README

## Testing
- `pytest tests/test_agents.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'jwt')*

------
https://chatgpt.com/codex/tasks/task_e_683b74952ee4832e963ba6974863906c