### PR TITLE
Fix Pulumi token usage

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,6 +21,7 @@ jobs:
         working-directory: infra
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+          PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
       - name: Ensure dev stack exists
         run: pulumi stack select dev --create --non-interactive
         working-directory: infra


### PR DESCRIPTION
## Summary
- fix Pulumi config step to use PULUMI_ACCESS_TOKEN

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'jwt')*

------
https://chatgpt.com/codex/tasks/task_e_683b74e09db0832e84b78ad4a1a288df