### PR TITLE
Deploy UI container

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,6 @@
+FROM python:3.11-slim
+WORKDIR /app
+COPY . /app
+RUN pip install --no-cache-dir chainlit fastapi uvicorn requests jinja2
+EXPOSE 8000
+CMD ["bash", "-c", "chainlit run chat_client/chainlit_app.py --host 0.0.0.0 --port 8000"]

--- a/README.md
+++ b/README.md
@@ -167,9 +167,12 @@ assistant reply:
 2. Publish the functions to Azure:
 
    ```bash
-   cd ../azure-function
-   func azure functionapp publish event-function
-   ```
+ cd ../azure-function
+  func azure functionapp publish event-function
+  ```
+
+The stack also provisions a container instance running the Chainlit UI and
+dashboard. Pulumi exports the container's public URL as `uiUrl`.
 
 If deploying manually, ensure `OPENAI_API_KEY` is configured on the Function App
 before publishing. The GitHub Actions workflow reads the `OPENAI_API_KEY` secret

--- a/chat_client/chainlit_app.py
+++ b/chat_client/chainlit_app.py
@@ -6,6 +6,7 @@ import requests
 import chainlit as cl
 from fastapi import HTTPException
 from chainlit.server import app as fastapi_app
+from dashboard.app import app as dashboard_app
 
 EVENT_API_URL = os.environ.get("EVENT_API_URL")
 AUTH_TOKEN = os.environ.get("AUTH_TOKEN")
@@ -52,3 +53,6 @@ async def notify(payload: dict):
 
     await cl.Message(content=message, author=user_id or "assistant").send()
     return {"status": "ok"}
+
+# Expose the dashboard under /dashboard on the Chainlit FastAPI app
+fastapi_app.mount("/dashboard", dashboard_app)

--- a/infra/__main__.py
+++ b/infra/__main__.py
@@ -5,6 +5,7 @@ from pulumi_azure_native import (
     storage,
     web,
     authorization,
+    containerinstance,
 )
 from pulumi_azure_native.authorization import get_client_config, RoleAssignment
 
@@ -150,3 +151,47 @@ pulumi.export(
     "functionEndpoint",
     pulumi.Output.concat("https://", func_app.default_host_name, "/api/events"),
 )
+
+# Container group hosting the Chainlit app and dashboard
+
+ui_image = config.get("uiImage") or "chainlit-dashboard"
+
+ui_container = containerinstance.ContainerGroup(
+    "chat-ui",
+    resource_group_name=resource_group.name,
+    container_group_name="chat-ui",
+    location=resource_group.location,
+    os_type="Linux",
+    containers=[
+        containerinstance.ContainerArgs(
+            name="chat-ui",
+            image=ui_image,
+            ports=[
+                containerinstance.ContainerPortArgs(port=8000),
+            ],
+            environment_variables=[
+                containerinstance.EnvironmentVariableArgs(
+                    name="EVENT_API_URL",
+                    value=pulumi.Output.concat(
+                        "https://", func_app.default_host_name, "/api/events"
+                    ),
+                ),
+                containerinstance.EnvironmentVariableArgs(
+                    name="API_BASE",
+                    value=pulumi.Output.concat(
+                        "https://", func_app.default_host_name, "/api"
+                    ),
+                ),
+            ],
+            resources=containerinstance.ResourceRequirementsArgs(
+                requests=containerinstance.ResourceRequestsArgs(cpu=1.0, memory_in_gb=1.0)
+            ),
+        )
+    ],
+    ip_address=containerinstance.IpAddressArgs(
+        ports=[containerinstance.PortArgs(protocol="TCP", port=8000)],
+        type=containerinstance.ContainerGroupIpAddressType.PUBLIC,
+    ),
+)
+
+pulumi.export("uiUrl", ui_container.ip_address.apply(lambda ip: f"http://{ip.fqdn}"))

--- a/tests/test_chainlit_app.py
+++ b/tests/test_chainlit_app.py
@@ -23,7 +23,9 @@ def load_chainlit_app(monkeypatch, capture):
 
     cl_mod.on_message = on_message
     cl_mod.Message = Msg
-    app_obj = types.SimpleNamespace(post=lambda path: (lambda f: f))
+    def mount(path, app, **kw):
+        pass
+    app_obj = types.SimpleNamespace(post=lambda path: (lambda f: f), mount=mount)
     cl_mod.server = types.SimpleNamespace(app=app_obj)
     monkeypatch.setitem(sys.modules, 'chainlit', cl_mod)
     monkeypatch.setitem(sys.modules, 'chainlit.server', types.SimpleNamespace(app=app_obj))
@@ -34,7 +36,59 @@ def load_chainlit_app(monkeypatch, capture):
         def __init__(self, status_code, detail=None):
             self.status_code = status_code
             self.detail = detail
+    class FastAPI:
+        def mount(self, *a, **kw):
+            pass
+        def get(self, *a, **kw):
+            def wrapper(f):
+                return f
+            return wrapper
+        def post(self, *a, **kw):
+            def wrapper(f):
+                return f
+            return wrapper
+    def Depends(obj):
+        return obj
+    class Jinja2Templates:
+        def __init__(self, directory):
+            pass
+    class RedirectResponse:
+        def __init__(self, *a, **kw):
+            pass
+    class HTMLResponse:
+        pass
+    class StaticFiles:
+        def __init__(self, *a, **kw):
+            pass
     fastapi_mod.HTTPException = HTTPException
+    fastapi_mod.FastAPI = FastAPI
+    fastapi_mod.Depends = Depends
+    fastapi_mod.Jinja2Templates = Jinja2Templates
+    fastapi_mod.RedirectResponse = RedirectResponse
+    fastapi_mod.HTMLResponse = HTMLResponse
+    fastapi_mod.StaticFiles = StaticFiles
+    templating_mod = types.ModuleType('fastapi.templating')
+    templating_mod.Jinja2Templates = Jinja2Templates
+    responses_mod = types.ModuleType('fastapi.responses')
+    responses_mod.RedirectResponse = RedirectResponse
+    responses_mod.HTMLResponse = HTMLResponse
+    staticfiles_mod = types.ModuleType('fastapi.staticfiles')
+    staticfiles_mod.StaticFiles = StaticFiles
+    monkeypatch.setitem(sys.modules, 'fastapi.templating', templating_mod)
+    monkeypatch.setitem(sys.modules, 'fastapi.responses', responses_mod)
+    monkeypatch.setitem(sys.modules, 'fastapi.staticfiles', staticfiles_mod)
+    # Stub pydantic
+    pydantic_mod = types.ModuleType('pydantic')
+    class BaseModel:
+        pass
+    pydantic_mod.BaseModel = BaseModel
+    monkeypatch.setitem(sys.modules, 'pydantic', pydantic_mod)
+    # Stub starlette
+    starlette_mod = types.ModuleType('starlette.requests')
+    class Request:
+        pass
+    starlette_mod.Request = Request
+    monkeypatch.setitem(sys.modules, 'starlette.requests', starlette_mod)
     monkeypatch.setitem(sys.modules, 'fastapi', fastapi_mod)
 
     # Stub requests


### PR DESCRIPTION
## Summary
- create a Dockerfile for running Chainlit and the dashboard
- mount the dashboard on the Chainlit FastAPI app
- update Pulumi template to provision an ACI container group for the UI
- mention the UI container in the README
- adjust tests for the new dashboard integration

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683b769d8664832eae92302a800c9724