### PR TITLE
Add OpenAI shell agent

### DIFF
--- a/agents/__init__.py
+++ b/agents/__init__.py
@@ -26,3 +26,4 @@ def register(agent_cls: type) -> type:
 
 
 from . import echo_agent  # noqa: F401  # register built-in agents
+from . import openai_shell_agent  # noqa: F401

--- a/agents/openai_shell_agent.py
+++ b/agents/openai_shell_agent.py
@@ -1,0 +1,39 @@
+from typing import List
+import os
+import subprocess
+
+from . import Agent, register
+
+
+@register
+class OpenAIShellAgent(Agent):
+    """Agent that uses OpenAI to translate instructions into shell commands and
+    executes them in the local bash environment."""
+
+    name = "openai-shell"
+
+    def run(self, commands: List[str]) -> str:
+        try:
+            import openai
+        except ModuleNotFoundError as e:
+            raise RuntimeError("openai library required") from e
+
+        api_key = os.environ.get("OPENAI_API_KEY")
+        if not api_key:
+            raise RuntimeError("OPENAI_API_KEY not set")
+        openai.api_key = api_key
+        model = os.environ.get("OPENAI_MODEL", "gpt-3.5-turbo")
+
+        outputs = []
+        for instruction in commands:
+            response = openai.ChatCompletion.create(
+                messages=[
+                    {"role": "system", "content": "Return a bash command for the given instruction."},
+                    {"role": "user", "content": instruction},
+                ],
+                model=model,
+            )
+            cmd = response["choices"][0]["message"]["content"]
+            proc = subprocess.run(cmd, shell=True, capture_output=True, text=True)
+            outputs.append(proc.stdout)
+        return "".join(outputs)

--- a/tests/test_agents.py
+++ b/tests/test_agents.py
@@ -1,4 +1,4 @@
-import sys, os
+import sys, os, types
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), '..')))
 from agents import AGENT_REGISTRY
@@ -9,3 +9,26 @@ def test_echo_agent_registry():
     agent = AGENT_REGISTRY['echo']
     result = agent.run(['hi', 'there'])
     assert result == 'hi\nthere'
+
+
+def test_openai_shell_agent(monkeypatch):
+    assert 'openai-shell' in AGENT_REGISTRY
+    agent = AGENT_REGISTRY['openai-shell']
+
+    captured = {}
+
+    class ChatStub:
+        @staticmethod
+        def create(messages=None, model=None):
+            captured['messages'] = messages
+            captured['model'] = model
+            return {"choices": [{"message": {"content": "echo hello"}}]}
+
+    openai_stub = types.SimpleNamespace(ChatCompletion=ChatStub)
+    monkeypatch.setitem(sys.modules, 'openai', openai_stub)
+    monkeypatch.setenv('OPENAI_API_KEY', 'sk')
+    monkeypatch.setenv('OPENAI_MODEL', 'model-test')
+
+    result = agent.run(['say hello'])
+    assert 'hello' in result
+    assert captured['model'] == 'model-test'


### PR DESCRIPTION
## Summary
- add `OpenAIShellAgent` which uses OpenAI to generate bash commands and executes them
- register the new agent
- test the new agent

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683b764b83dc832e99b904c46ce0044f