### PR TITLE
Wire Chainlit notifier via Pulumi

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,6 +22,12 @@ jobs:
         env:
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
+      - name: Configure JWT signing key
+        run: pulumi config set jwtSigningKey "$JWT_SIGNING_KEY" --secret
+        working-directory: infra
+        env:
+          JWT_SIGNING_KEY: ${{ secrets.JWT_SIGNING_KEY }}
+          PULUMI_ACCESS_TOKEN: ${{ secrets.PULUMI_ACCESS_TOKEN }}
       - name: Ensure dev stack exists
         run: pulumi stack select dev --create --non-interactive
         working-directory: infra

--- a/README.md
+++ b/README.md
@@ -156,11 +156,15 @@ assistant reply:
 
 ### Deployment
 
-1. Deploy the infrastructure with Pulumi:
+1. Deploy the infrastructure with Pulumi. Set the required configuration
+   values for the OpenAI key and JWT signing key. The NOTIFY_URL used by the
+   functions is derived automatically from the Chainlit container's address:
 
    ```bash
    cd infra
    pip install -r requirements.txt
+   pulumi config set openaiApiKey <key> --secret
+   pulumi config set jwtSigningKey <secret> --secret
    pulumi up
    ```
 
@@ -193,7 +197,8 @@ messaging:
   namespace.
 - `SERVICEBUS_QUEUE` &mdash; queue name for publishing and receiving events.
 - `NOTIFY_URL` &mdash; endpoint that `UserMessenger` calls to deliver messages
-  to the chat client.
+  to the chat client. Pulumi sets this automatically based on the Chainlit
+  container address.
 - `JWT_SIGNING_KEY` &mdash; HMAC key used to validate bearer tokens.
 - `COSMOS_CONNECTION` &mdash; connection string for the Cosmos DB account.
 - `COSMOS_DATABASE` &mdash; database name (defaults to `lightning`).


### PR DESCRIPTION
## Summary
- wire up Chainlit container with the function app via Pulumi
- automatically set NOTIFY_URL from the container FQDN
- configure jwtSigningKey from GitHub secrets
- update docs and workflow

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683b754cc7cc832ebd0b4dadfbc8e97c